### PR TITLE
Add scaffolding to enable snap build of commento

### DIFF
--- a/snap/scripts/launch_commento
+++ b/snap/scripts/launch_commento
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ! -f $SNAP_USER_DATA/assets ];
+then
+  echo "No assets found will copy"
+  mkdir -p $SNAP_USER_DATA/assets
+  cp $SNAP/assets/* $SNAP_USER_DATA/assets/
+fi
+
+cd $SNAP_USER_DATA
+
+exec $SNAP/bin/commento

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: commento
+version: 'master'
+summary: A lightweight, open source, tracking-free comment engine alternative to Disqus
+description: |
+  An open source, lightweight, and tracking-free comment engine.
+
+grade: stable
+confinement: strict
+
+apps:
+  commento: 
+    command: launch_commento
+    plugs:
+      - network
+      - network-bind
+
+parts:
+  scripts:
+    plugin: dump
+    source: snap/scripts
+    organize:
+      'launch': bin/
+  assets:
+    plugin: dump
+    source: assets
+    organize:
+      '*': assets/
+  commento:
+    plugin: go
+    source: .
+    go-importpath: github.com/adtac/commento
+    build-packages:
+      - build-essential


### PR DESCRIPTION
Thanks for making commento! It's a great compliment to other free software tools that I already use like Nikola for static site generation. I look forward to being able to migrate away from disqus! :)

This prototype PR adds the configuration and support files to generate a snap of commento. Snaps can be installed on multiple Linux distributions, are secure, and can be updated by the developer on their own cadence. Once landed, you can go to http://build.snapcraft.io/ and have it build and publish commento automatically to the edge channel in the store on every commit to master. Once published, users can install the latest build with ```snap install commento --edge```. When you're ready to release, you can can release to the stable channel, where users can easily install in the same way, omitting the ```--edge``` parameter. You can find out more about snaps at http://snapcraft.io/

To test this PR on an Ubuntu 16.04 machine:-

```
$ sudo apt install git snapcraft
$ git clone https://github.com/popey/commento
$ cd commento
$ git checkout add-snapcraft
$ snapcraft
$ sudo snap install *.snap --dangerous
```

(the ```--dangerous``` part is just because it's an unsigned package built locally rather than from the store).

I had to wrap commento in a little script so that it could find the web assets and put the sqlite3 db in the right location. 