### PR TITLE
Enhancements: configurable database file path, default port, and optimised Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*.db
+*.md
+.dockerfile
+.editorconfig
+.gitignore
+Dockerfile
+example/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ RUN /bin/bash -c "source /tmp/nvm/nvm.sh && npm install"
 RUN /bin/bash -c "source /tmp/nvm/nvm.sh && npm run-script build"
 RUN cp /go/src/commento/assets /go/bin/assets -vr
 
+RUN mkdir /data/
+
 # set entrypoint
 ENTRYPOINT /go/bin/commento

--- a/config.go
+++ b/config.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	"strings"
-	"os"
 	"github.com/joho/godotenv"
+	"os"
+	"strings"
 )
 
 func loadConfig() error {
 	// Default value for each environment variable.
 	env := map[string]string{
-		"COMMENTO_PORT": "8080",
+		"COMMENTO_DATABASE_FILE": "sqlite3.db",
+		"COMMENTO_PORT":          "8080",
 	}
 
 	// Load configuration from the environment. Final value is governed by the

--- a/main.go
+++ b/main.go
@@ -11,12 +11,13 @@ import (
 func main() {
 	var err error
 
-	err = LoadDatabase("sqlite:file=sqlite3.db")
+	err = loadConfig()
 	if err != nil {
 		Die(err)
 	}
 
-	err = loadConfig()
+	fp := os.Getenv("COMMENTO_DATABASE_FILE")
+	err = LoadDatabase("sqlite:file=" + fp)
 	if err != nil {
 		Die(err)
 	}
@@ -29,7 +30,6 @@ func main() {
 	http.HandleFunc("/get", GetCommentsHandler)
 
 	port := os.Getenv("COMMENTO_PORT")
-
 	svr := &http.Server{
 		Addr:         ":" + port,
 		ReadTimeout:  5 * time.Second,


### PR DESCRIPTION
**Configurable database file path**

The sqlite3 database file path is currently hardcoded. It'd be great if it can be configured. For example, if we were to mount a Docker volume for persistence, it'd be far easier if we could mount a data directory rather than a specific file which most implementations do not nicely support, e.g. Rancher. 

**Default port**

I noticed that there's no default set, and the binding can be set to `:`. I have set it to `8080` as per the default environment variable for it.

**Optimised Docker image**

The main goal here is to optimise for caching, build speed and final image size. It takes advantage of a multi-stage Docker build.

- Build backend, and frontend in separate images
- Copy artifacts from build images to final, execution image
- Add `.dockerignore` to speed up build times (and improve caching)
- Copy, and install npm packages before building (again, to improve caching)
- Build Go binary statically

The final size is under 20MB compared to the hundreds.
