### PR TITLE
Remove hash from window.location

### DIFF
--- a/assets/js/commento.js
+++ b/assets/js/commento.js
@@ -281,11 +281,11 @@
     var _serverUrl = '';
     var _honeypot = false;
     var _api = {};
-
+    var _location = window.location.href.replace(window.location.hash, '');
 
     var _getComments = function(callback) {
         var data = {
-            "url": document.location
+            "url": _location
         };
         post(_api.get, data, function(reply) {
             var response = {
@@ -419,7 +419,7 @@
         }
 
         data = {
-            url: document.location,
+            url: _location,
             comment: $rootComment.value,
             name: $rootName.value,
             parent: -1
@@ -460,7 +460,7 @@
             comment: textareaValue,
             name: nameInputValue,
             parent: id,
-            url: document.location
+            url: _location
         };
 
         if(_honeypot){


### PR DESCRIPTION
Got those `hash` saved in my database, thought they needs to be removed, or user can only see those comments when they access the url with hash exactly.

<img width="514" alt="image" src="https://user-images.githubusercontent.com/1091472/39037780-1b73d694-44b4-11e8-892b-4b60bc3e3c63.png">
