### PR TITLE
commento.js: Commento can be manually initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ To embed Commento in your website, paste the following HTML snippet wherever you
 
 Commento will simply fill the container it is placed in. Remember to change `server.com` to your server.
 
+If `data-div` is not set then Commento will not automatically load, but you can manually initialize it with the options listed below:
+
+```html
+<div id="commento"></div>
+<script src="http://server.com/assets/js/commento.min.js">
+</script>
+<script>
+Commento.init({
+  serverUrl: 'http://server.com', // Your Commento server address. Required.
+  divId: 'commento', // Id of the element to load Commento into. Required.
+  honeypot: true, // Enable honeypot field for extra spam protection. Default: false.
+  commentoCssUrl: 'http://server.com/alternative-commento.css' // Url to custom css to load when Commento loads. Default: http://server.com/assets/css/commento.min.css
+});
+</script>
+```
+
 ### Configuration
 
 #### Configuring the Backend

--- a/assets/js/commento.js
+++ b/assets/js/commento.js
@@ -60,7 +60,8 @@
     }
 
     function getAttr(node, attr) {
-        return node.attributes[attr].value;
+        var attribute = node.attributes[attr];
+        return attribute && attribute.value
     }
 
     function setAttr(node, attr, value) {
@@ -651,9 +652,11 @@
 
         for (var i = 0; i < scripts.length; i++) {
             if (scripts[i].src.match(/commento(?:\.min)?\.js$/)) {
+                var divId = getAttr(scripts[i], "data-div");
+                if (!divId) break;
                 Commento.init({
                     serverUrl: stripPath(scripts[i].src),
-                    divId: getAttr(scripts[i], "data-div").substr(1),
+                    divId: divId.substr(1),
                 });
                 break;
             }


### PR DESCRIPTION
I wanted to set a custom css url but it seems that with the new autoload feature this isn't possible. 

Slight tweak to make this possible and added some docs for extra `init` options.