### PR TITLE
Support one click deployment to Heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY --from=frontend-build /commento/frontend/build/${RELEASE}/*.html /commento/
 COPY --from=templates-db-build /commento/templates/build/${RELEASE}/templates /commento/templates/
 COPY --from=templates-db-build /commento/db/build/${RELEASE}/db /commento/db/
 
-EXPOSE 8080
+EXPOSE ${COMMENTO_PORT:-$PORT}
 WORKDIR /commento/
 ENV COMMENTO_BIND_ADDRESS="0.0.0.0"
-ENTRYPOINT ["/commento/commento"]
+ENTRYPOINT "COMMENTO_PORT=${COMMENTO_PORT:-$PORT} COMMENTO_POSTGRES=${COMMENTO_POSTGRES:-$DATABASE_URL} /commento/commento"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For starters, your readers value their privacy. Not caring about them is disresp
 
 Read the [documentation to get started](https://docs.commento.io/installation/).
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/adtac/commento)
+
 #### Contributing
 
 If this is your first contribution to Commento, please go through the [contribution guidelines](https://docs.commento.io/contributing/) before you begin. If you have any questions, join [#commento on Freenode](http://webchat.freenode.net/?channels=%23commento).

--- a/app.json
+++ b/app.json
@@ -1,0 +1,24 @@
+{
+  "name": "Commento",
+  "description": "A fast, privacy-focused commenting platform.",
+  "repository": "https://gitlab.com/commento/commento",
+  "logo": "https://cdn.commento.io/images/logo.svg",
+  "website": "https://commento.io",
+  "keywords": ["goalang", "commento", "privacy"],
+  "stack": "container",
+  "addons": [
+    {
+      "plan": "heroku-postgresql"
+    }
+  ],
+  "success_url": "/login",
+  "env": {
+    "COMMENTO_ORIGIN": {
+      "description": "This should be set to the subdomain or the IP address hosting Commento. All API requests will go to this server. This may include subdirectories if Commento is hosted behind a reverse proxy, for example. Include the protocol in the value to use HTTP/HTTPS."
+    },
+    "COMMENTO_FORBID_NEW_OWNERS": {
+      "description": "Used to disable new dashboard registrations. Useful if you are the only person using Commento on your server. Does not impact the creation of accounts for your readers. Defaults to false.",
+      "value": "false"
+    }
+  }
+}

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,8 @@
+setup:
+  addons:
+    - plan: heroku-postgresql
+      as: DATABASE
+
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
To make it super easy to deploy a self-hosted instance, we can add a one-click deployment to Heroku button.  This is inspired by what is available on Commento++.